### PR TITLE
Enable usage of XRay Trace ID

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -30,6 +30,7 @@ runtime.open(
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
         "AWS_SECURITY_TOKEN",
+        "_X_AMZN_TRACE_ID",
     )) if v})
 )
 

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -40,5 +40,6 @@ class Proxy(object):
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",
                 "AWS_SECURITY_TOKEN",
+                "_X_AMZN_TRACE_ID",
             )) if v}),
             ctx.log, ctx.get_remaining_time_in_millis))

--- a/tests/env/handler.go
+++ b/tests/env/handler.go
@@ -30,6 +30,7 @@ func init() {
 	ok = ok && os.Getenv("AWS_SECRET_ACCESS_KEY") == "i2"
 	ok = ok && os.Getenv("AWS_SESSION_TOKEN") == "i3"
 	ok = ok && os.Getenv("AWS_SECURITY_TOKEN") == "i4"
+	ok = ok && os.Getenv("_X_AMZN_TRACE_ID") == "i5"
 }
 
 func Handle(interface{}, *runtime.Context) (interface{}, error) {
@@ -42,5 +43,6 @@ func Handle(interface{}, *runtime.Context) (interface{}, error) {
 		os.Getenv("AWS_SECRET_ACCESS_KEY"),
 		os.Getenv("AWS_SESSION_TOKEN"),
 		os.Getenv("AWS_SECURITY_TOKEN"),
+		os.Getenv("_X_AMZN_TRACE_ID"),
 	}, nil
 }

--- a/tests/env/test.py
+++ b/tests/env/test.py
@@ -21,6 +21,7 @@ os.environ["AWS_ACCESS_KEY_ID"] = "i1"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "i2"
 os.environ["AWS_SESSION_TOKEN"] = "i3"
 os.environ["AWS_SECURITY_TOKEN"] = "i4"
+os.environ["_X_AMZN_TRACE_ID"] = "i5"
 
 import handler
 
@@ -36,12 +37,13 @@ class TestCase(unittest.TestCase):
 
     def test_case(self):
         try:
-            self.assertEqual(["i1", "i2", "i3", "i4"], handler.Handle({}, Context()))
+            self.assertEqual(["i1", "i2", "i3", "i4", "i5"], handler.Handle({}, Context()))
             os.environ["AWS_ACCESS_KEY_ID"] = "h1"
             os.environ["AWS_SECRET_ACCESS_KEY"] = "h2"
             os.environ["AWS_SESSION_TOKEN"] = "h3"
             os.environ["AWS_SECURITY_TOKEN"] = "h4"
-            self.assertEqual(["h1", "h2", "h3", "h4"], handler.Handle({}, Context()))
+            os.environ["_X_AMZN_TRACE_ID"] = "h5"
+            self.assertEqual(["h1", "h2", "h3", "h4", "h5"], handler.Handle({}, Context()))
         except Exception:
             self.fail("should not raise")
 


### PR DESCRIPTION
Just like AWS Lambda temporary credentials, XRay Trace ID may change between invocations. The go env space being separated from the python env space, we have to re-inject these changing env variables before each invocation to be sure they are up to date.

CAT: #feat 
REF: #45 
THX: @tobowers